### PR TITLE
Purge CloudFront CDN on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
 - 2.1
 script:
 - npm install
-- grunt deploy
+- grunt test
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
@@ -11,9 +11,8 @@ notifications:
   email: false
 deploy:
   provider: s3
-  access_key_id: AKIAJZQ3D6IQ27SQJVYA
-  secret_access_key:
-    secure: "ftk6/CkME/AQ9LWO7EE+6SmOheeizCN9zTIxjXcPYdvFAGF6P7Oy1ho6OIOUcn5GavNg4Yes+idAwKJrs7ktjSw6b0vNFG9iHL/W9HBOXOC9V0DkPJHvA7PtNHVzE2xaKNSg4/NTEsPw6HlH/L5tG4Rjzr5i0Sx6BAwlRzAjswk="
+  access_key_id: $AWS_KEY
+  secret_access_key: $AWS_SECRET
   bucket: informatics-blog
   local-dir: _site
   acl: public_read
@@ -21,3 +20,5 @@ deploy:
   region: eu-west-1
   on:
     branch: master
+after_deploy:
+- grunt purge

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,15 +29,32 @@ module.exports = function(grunt) {
     },
 
     "shell": {
-        bundleInstall: {
-          command: "bundle install"
-        },
-        jekyllTest: {
-            command: "bundle exec htmlproof ./_site --only-4xx"
-        },
-        runTests: {
-          command: "for SCRIPT in tests/*; do if [ -f $SCRIPT -a -x $SCRIPT ]; then $SCRIPT; fi; done"
-        }
+      bundleInstall: {
+        command: "bundle install"
+      },
+      jekyllTest: {
+        command: "bundle exec htmlproof ./_site --only-4xx"
+      },
+      runTests: {
+        command: "for SCRIPT in tests/*; do if [ -f $SCRIPT -a -x $SCRIPT ]; then $SCRIPT; fi; done"
+      }
+    },
+
+    invalidate_cloudfront: {
+      options: {
+        key: process.env.AWS_KEY,
+        secret: process.env.AWS_SECRET,
+        distribution: 'E3IDIFQ6VR6DB8'
+      },
+      production: {
+        files: [{
+          expand: true,
+          cwd: './_site/',
+          src: ['**/*'],
+          filter: 'isFile',
+          dest: ''
+        }]
+      }
     }
   });
 
@@ -45,9 +62,11 @@ module.exports = function(grunt) {
   grunt.registerTask("installDeps", ["shell:bundleInstall", "bower"]);
 
   // Public tasks
-  grunt.registerTask("serve", ["installDeps", "jekyll:serve" ]);
-  grunt.registerTask("deploy", ["installDeps", "jekyll:build", "shell:jekyllTest", "shell:runTests" ]);
+  grunt.registerTask("serve", ["installDeps", "jekyll:serve"]);
+  grunt.registerTask("build", ["installDeps", "jekyll:build"]);
+  grunt.registerTask("test", ["build", "shell:jekyllTest", "shell:runTests"]);
+  grunt.registerTask("purge", ["invalidate_cloudfront:production"]);
 
   // Default task
-  grunt.registerTask("default", [ "serve" ]);
+  grunt.registerTask("default", ["serve"]);
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "grunt": "^0.4.5",
     "grunt-bower-task": "^0.4.0",
     "grunt-contrib-jshint": "^0.11.2",
+    "grunt-invalidate-cloudfront": "^0.1.6",
     "grunt-jekyll": "^0.4.2",
     "grunt-shell": "^1.1.2",
     "load-grunt-tasks": "^3.1.0"


### PR DESCRIPTION
As part of #168 the blog was moved to a different S3 bucket and put behind a CloudFront CDN. This caches the requests to the bucket and makes it very performant and cheaper to run.

However when we deploy new code to the bucket the CDN will still serve the old content for a while, therefore we need to purge the CDN at the same time.

I've added the ability to do this in grunt and set travis to run this after a successful deployment.

I also decided to remove the encrypted AWS credentials from the `.travis.yml` file and set them as environment variables in the Travis control panel. This way grunt can also access them and it makes them easier to maintain.