### PR TITLE
Changed to using CDN bootstrap

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,7 +23,7 @@
 <script src="/lib/jquery/jquery.js"></script>
 
 <!-- Bootstrap Core JavaScript -->
-<script src="/lib/bootstrap/bootstrap.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
 
 <!-- Plugin JavaScript -->
 <script src="/lib/jquery-easing/jquery.easing.min.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
     <title>{{ site.title }}</title>
 
     <!-- Bootstrap Core CSS -->
-    <link href="/lib/bootstrap/bootstrap.css" rel="stylesheet"/>
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet"/>
     <link href="/lib/font-awesome/css/font-awesome.css" rel="stylesheet"/>
     <link href="/css/styles.css" rel="stylesheet"/>
 

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "www.informaticslab.co.uk",
   "dependencies": {
     "font-awesome": "~4.3.0",
-    "bootstrap": "~3.3.4",
     "classie": "~1.0.1",
     "jqBootstrapValidation": "~1.3.7",
     "jquery-easing": "*",


### PR DESCRIPTION
Seems the bower version of bootstrap changed some things and broke. I've moved that dependancy out of bower to use the CDN version instead.