### PR TITLE
If header image specified in article then override

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,11 @@ layout: default
 {% include navigation.html %}
 
 <!-- Header image -->
-<header style="background-image: url(/img/home-main-header.jpg);">
+{% if page.header %}
+  <header style="background-image: url({{ page.header }});">
+{% else %}
+  <header style="background-image: url(/img/home-main-header.jpg);">
+{% endif %}
     <div class="container">
         <div class="intro-text">
             <div class="intro-heading"><span>{{ page.title }}</span></div>


### PR DESCRIPTION
Currently all articles have the same header image. This PR adds some liquid which checks if an alternate header image has been specified in the post's YAML and uses that if that's the case.

This should make articles more interesting and individual.