### PR TITLE
Added fenced code blocks to markdown parser

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,11 @@ google_analytics: 'UA-60337429-1'
 #Build stuff
 #-----------
 
+#markdown options
+markdown: redcarpet
+redcarpet:
+  extensions: ["fenced_code_blocks"]
+
 #build output dir
 destination: _site
 


### PR DESCRIPTION
Added an extension to the markdown parser to allow fenced code blocks. Main benefit is multiline code blocks. Before this it would treat code written over multiple lines as inline code blocks.

#### Screenshot before
![image](https://cloud.githubusercontent.com/assets/1610850/8308436/967e43ea-19bc-11e5-8c7d-31e496fdbf06.png)

#### Screenshot after
![image](https://cloud.githubusercontent.com/assets/1610850/8308424/85dcd204-19bc-11e5-9696-99aa0bf21e5e.png)
