### PR TITLE
Add callouts to markdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ google_analytics: 'UA-60337429-1'
 #-----------
 
 #markdown options
-markdown: redcarpet
+markdown: labredcarpet
 redcarpet:
   extensions: ["fenced_code_blocks"]
 

--- a/_plugins/redcarpet-custom-renderer.rb
+++ b/_plugins/redcarpet-custom-renderer.rb
@@ -1,0 +1,71 @@
+require 'redcarpet'
+
+# Create new renderer extending Redcrpet
+class LabRedcarpet < Redcarpet::Render::HTML
+
+  # List of extensions
+  # Extensions are basically just regular expressions
+  @@extensions = []
+
+  # Add a new extension to the list
+  def self.extension(title, regexp = nil, &block)
+    regexp ||= %r${::#{title}}(.*?){:/#{title}}$m
+    @@extensions << [title, regexp, block]
+  end
+
+  # Helper function to generate regex for a string surrounded by two tags
+  def self.surrounded_by(tag)
+    tag = Regexp::escape(tag)
+    %r+(?:\r|\n|^)#{tag}(.*?)#{tag}? *(\r|\n|$)+m
+  end
+
+  ##
+  # Extensions
+  ###
+
+  # Information is surrounded by ^
+  extension('informational', surrounded_by("^")) { |body|
+    %{\n\n<p class="callout callout-info">#{body}</p>\n}
+  }
+
+  # Warnings are surrounded by %
+  extension('warning', surrounded_by("%")) { |body|
+    %{\n\n<p class="callout callout-warning">#{body}</p>\n}
+  }
+
+  # Advisories are surrounded by @
+  extension('advisory', surrounded_by("@")) { |body|
+    %{\n\n<p class="callout callout-danger">#{body}</p>\n}
+  }
+
+  ##
+  # This function is a hook to Redcarpet which preprocesses the markdown file
+  # through our extensions.
+  def preprocess(source)
+    @@extensions.each do |title,regexp,block|
+      source.gsub!(regexp) {
+        instance_exec(*Regexp.last_match.captures, &block)
+      }
+    end
+    source
+  end
+
+end
+
+##
+# Add new renderer to jekyll
+###
+class Jekyll::Converters::Markdown
+  def extensions
+    Hash[ *@config['redcarpet']['extensions'].map {|e| [e.to_sym, true] }.flatten ]
+  end
+
+  def markdown
+    @markdown ||= Redcarpet::Markdown.new(LabRedcarpet.new(extensions), extensions)
+  end
+
+  def convert(content)
+    return super unless @config['markdown'] == 'labredcarpet'
+    markdown.render(content)
+  end
+end

--- a/_sass/meto-informatics-lab/post.scss
+++ b/_sass/meto-informatics-lab/post.scss
@@ -24,3 +24,43 @@
     font-style: italic;
   }
 }
+
+/* Side notes for calling out things
+-------------------------------------------------- */
+
+/* Base styles (regardless of theme) */
+.callout {
+  padding: 10px;
+  margin: 10px 0;
+  border: 1px solid #eee;
+  border-left-width: 5px;
+  border-radius: 3px;
+
+  h4 {
+    margin-top: 0;
+    margin-bottom: 5px;
+  }
+  p:last-child {
+    margin-bottom: 0;
+  }
+}
+
+/* Themes for different contexts */
+.callout-danger {
+  border-left-color: #ce4844;
+  h4 {
+    color: #ce4844;
+  }
+}
+.callout-warning {
+  border-left-color: #aa6708;
+  h4 {
+    color: #aa6708;
+  }
+}
+.callout-info {
+  border-left-color: #1b809e;
+  h4 {
+    color: #1b809e;
+  }
+}


### PR DESCRIPTION
I want to add bootstrap callouts to our articles. These are sections which are highlighted for a specific reason. They can look something like this:

![image](https://cloud.githubusercontent.com/assets/1610850/8325135/eaea55d0-1a4e-11e5-8a54-bb297eda5828.png)

They are similar to `blockquote` and `codeblock` elements and are especially useful when writing a tutorial as you can highlight additional information, warn about gotchas and give praise using them. It helps to break up text as well as give additional meaning

I've added a little css which mimics the callouts used in the bootstrap documentation but the problem I'm having is how to create them within the markdown articles. 

There doesn't seem to be a built in way in our markdown to do this and while putting HTML in markdown is possible it is not ideal. After a little research I found that [GovSpeak][gov-speak] (GOV.UK's customised markdown) adds this functionality in a two different ways, both of which they use. Firstly they have two standard callout types, `info` and `warning`. 

```
^This is an info callout^
%This is a warning callout%
```

I like this because it is similar to writing an inline `codeblock` which we already use.

```
`This is an inline codeblock`
```

They also have an extended version which encases a block with a `$` followed by a signifier. So an `example` callout would look like:

```
$E
This is an example callout
$E
```
And in the same way you could write an address like:

```
$A
Met Office
Fitzroy Road
Exeter
EX1 3PB
$A
```

I'm not sure I'm so bothered about the second style but I think I might try and figure out how to implement the first.

Thoughts?

[gov-speak]: https://github.com/alphagov/govspeak/wiki/Using-govspeak-on-GOV.UK