### PR TITLE
Removed trailing slash

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ author:        Met Office Lab
 short_description: "A lab at the Met Office for creating things!"
 description:   "The Met Office Informatics Lab combines scientists, software engineers, and designers to create new things. We try to rapidly prototype non-business-as-usual ideas that allow people from within the Met Office (and beyond) to make our science and data useful."
 baseurl:       ""
-url:           "http://www.informaticslab.co.uk/"
+url:           "http://www.informaticslab.co.uk"
 github-url:    "http://github.com/met-office-lab/"
 twitter-url:   "http://twitter.com/metolab/"
 instagram-url: "http://instagram.com/informaticslab/"


### PR DESCRIPTION
This was causing some urls to end up with a double slash and break.