### PR TITLE
Simon has left, changed from core to past-member

### DIFF
--- a/_profiles/simon-stanley.md
+++ b/_profiles/simon-stanley.md
@@ -2,7 +2,7 @@
 layout:     profile
 name:       Simon Stanley
 summary:    Simon is a maths man by trade and Python programmer by occupation.
-affiliation: core
+affiliation: past-member
 github-url: http://github.com/simonstanley
 email: simon.stanley87@gmail.com
 


### PR DESCRIPTION
To be merged by Simon as his last duty.

This will remove his image from the home page and add him to a group called `past-member`. We can use this to display our alumnus/alumna as members come and go.