### PR TITLE
Fixed broken link

### DIFF
--- a/_posts/2015-10-15-summer-placements.md
+++ b/_posts/2015-10-15-summer-placements.md
@@ -9,7 +9,7 @@ project:    None
 thumbnail: "https://dl.dropboxusercontent.com/u/2665124/blogimages/july-demos/icon.png"
 ---
 
-We've got some paid, 12 week [summer student placements](http://emea3.mrted.ly/ugo6) for 2016 to allow you to work with us here in the Informatics Lab (widely regarded as the coolest place in the Met Office<-N.B. *this is outrageous bias*).
+We've got some paid, 12 week [summer student placements](http://emea3.mrted.ly/uhhe) for 2016 to allow you to work with us here in the Informatics Lab (widely regarded as the coolest place in the Met Office<-N.B. *this is outrageous bias*).
 
 Here's the official job description, but with my extremely poor English from the original corrected...
     
@@ -24,4 +24,4 @@ And the required skills:
 
 Most importantly we'll need you to think! You're not just coding: you're working with us on a project using whatever approaches work best: coding, user lead design, paper prototyping, scientific analysis, and talking to other people who have been working on similar problems.
 
-If you're interested, visit [this site](http://emea3.mrted.ly/ugo6) to apply.
+If you're interested, visit [this site](http://emea3.mrted.ly/uhhe) to apply.


### PR DESCRIPTION
Old link goes to page saying 'This job is no longer available'. New link goes to Summer Placements 2016 page.