### PR TITLE
Fix font weights

### DIFF
--- a/_sass/meto-informatics-lab/_font_emeric.scss
+++ b/_sass/meto-informatics-lab/_font_emeric.scss
@@ -1,43 +1,60 @@
 @font-face {
     font-family: 'Emeric';
-    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Medium.ttf') format('truetype');
-    font-weight: normal;
+    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Thin.ttf') format('truetype');
+    font-weight: 200;
     font-style: normal;
 }
 @font-face {
     font-family: 'Emeric';
-    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Medium-Italic.ttf') format('truetype');
-    font-weight: normal;
-    font-style: italic;
-}
-@font-face {
-    font-family: 'Emeric';
-    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-SemiBold.ttf
-') format('truetype');
-    font-weight: bold;
-    font-style: normal;
-}
-@font-face {
-    font-family: 'Emeric';
-    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-SemiBold-Italic.ttf') format('truetype');
-    font-weight: bold;
-    font-style: italic;
-}
-@font-face {
-    font-family: 'Emeric';
-    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Heavy.ttf') format('truetype');
-    font-weight: bolder;
-    font-style: normal;
-}
-@font-face {
-    font-family: 'Emeric';
-    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Heavy-Italic.ttf') format('truetype');
-    font-weight: bolder;
+    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Thin-Italic.ttf') format('truetype');
+    font-weight: 200;
     font-style: italic;
 }
 @font-face {
     font-family: 'Emeric';
     src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Light.ttf') format('truetype');
-    font-weight: lighter;
+    font-weight: 400;
     font-style: normal;
+}
+@font-face {
+    font-family: 'Emeric';
+    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Light-Italic.ttf') format('truetype');
+    font-weight: 400;
+    font-style: italic;
+}
+@font-face {
+    font-family: 'Emeric';
+    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Medium.ttf') format('truetype');
+    font-weight: 500;
+    font-style: normal;
+}
+@font-face {
+    font-family: 'Emeric';
+    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Medium-Italic.ttf') format('truetype');
+    font-weight: 500;
+    font-style: italic;
+}
+@font-face {
+    font-family: 'Emeric';
+    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-SemiBold.ttf') format('truetype');
+    font-weight: 700;
+    font-style: normal;
+}
+@font-face {
+    font-family: 'Emeric';
+    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-SemiBold-Italic.ttf') format('truetype');
+    font-weight: 700;
+    font-style: italic;
+}
+@font-face {
+    font-family: 'Emeric';
+    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Heavy.ttf') format('truetype');
+    font-weight: 800;
+    font-style: normal;
+}
+@font-face {
+    font-family: 'Emeric';
+    src: url('https://s3-eu-west-1.amazonaws.com/informatics-webimages/fonts/emeric/FS-Emeric-Web-Heavy-Italic.ttf') format('truetype');
+    font-weight: 800;
+    font-style: italic;
 }


### PR DESCRIPTION
Assign weight by number instead of keyword. Bolder and lighter aren't weights, they are instructions to pick the weight above or below the inherited weight. 

#### Before
![image](https://cloud.githubusercontent.com/assets/1610850/13840955/deaa92b6-ec1d-11e5-9069-aa79ee0ec1f6.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1610850/13840972/f695896c-ec1d-11e5-815b-188d5b5006b9.png)
