### PR TITLE
Only include analytics in production

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -46,7 +46,7 @@ $( document ).ready(function() {
 <script src="/js/agency.js"></script>
 <script src="/js/molab.js"></script>
 
-{% if site.google_analytics %}
+{% if site.google_analytics and jekyll.environment == "production" %}
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Only display the analytics code in production builds.

In Travis we need to set the environment variable `JEKYLL_ENV=production`.