### PR TITLE
Updated twitter url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ description:   "The Met Office Informatics Lab combines scientists, engineers, t
 baseurl:       ""
 url:           "http://www.informaticslab.co.uk"
 github-url:    "http://github.com/met-office-lab/"
-twitter-url:   "http://twitter.com/informaticslab/"
+twitter-url:   "https://twitter.com/informatics_lab"
 instagram-url: "http://instagram.com/informaticslab/"
 calendar-url:  "/get-involved/calendar.html"
 image-bin:     "http://s3-eu-west-1.amazonaws.com/informatics-webimages/"

--- a/_profiles/alberto-arribas.md
+++ b/_profiles/alberto-arribas.md
@@ -3,7 +3,7 @@ layout:     profile
 name:       Alberto Arribas
 summary:    Head of Informatics Lab
 affiliation: core
-twitter-url: http://www.twitter.com/informaticslab
+twitter-url: https://twitter.com/informatics_lab
 github-url: https://github.com/alberto-arribas
 email: alberto.arribas@informaticslab.co.uk
 


### PR DESCRIPTION
The twitter url incorrectly points to `informaticslab` when it should be `informatics_lab`.