### PR TITLE
Updated mugshots and changed affiliation details

### DIFF
--- a/_includes/team-member.html
+++ b/_includes/team-member.html
@@ -2,7 +2,7 @@
 <div class="col-sm-6 col-md-3 col-lg-3">
     <div class="team-member">
         {% if profile.mugshot %}
-            {% capture mugshot %}{{ site.image-bin }}{{ profile.mugshot}}{% endcapture %}
+            {% capture mugshot %}{{profile.mugshot}}{% endcapture %}
         {% else %}
             {% assign mugshot = "http://www.gravatar.com/avatar/00000000000000000000000000000000?s=500&d=mm" %}
         {% endif %}

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -9,8 +9,10 @@
         </div>
         <div class="row">
             {% for profile in site.profiles %}
-                {% if profile.affiliation == 'core' %}
-                    {% include team-member.html %}
+                {% if profile.affiliation == 'core' or profile.affiliation == 'intern' %}
+                  {% if profile.current == true %}
+                      {% include team-member.html %}
+                  {% endif %}
                 {% endif %}
             {% endfor %}
         </div>

--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -11,14 +11,14 @@ layout: default
 	<article class="post-content profile">
     {% if page.mugshot %}
       <div class="team-member">
-        <div class="mugshot img-responsive" style="background-image: url({{ site.image-bin }}{{ page.mugshot }});">
+        <div class="mugshot img-responsive" style="background-image: url({{ page.mugshot }});">
         </div>
       </div>
     {% endif %}
 
     <h2>{{ page.name }}</h2>
     {% include team-social-links.html %}
-    
+
 		{{ content }}
 
 

--- a/_profiles/alastair-gemmell.md
+++ b/_profiles/alastair-gemmell.md
@@ -3,13 +3,14 @@ title: Alastair Gemmell
 layout: profile
 name: Alastair Gemmell
 summary: Alastair is a developer interested in data analysis and visualisation.
-affiliation: past-member
-twitter-url: 
-linkedin-url: 
+affiliation: core
+current: false
+twitter-url:
+linkedin-url:
 github-url: http://github.com/alastair-gemmell-lab
 email: alastair.gemmell@informaticslab.co.uk
-stackoverflow-url: 
-mugshot: alastair-gemmell.jpg
+stackoverflow-url:
+mugshot: https://images.informaticslab.co.uk/alastair-gemmell.jpg
 ---
 
 I joined the Met Office in 2012 having previously been based at the University of Reading where I worked primarily on visualising large scientific datasets. Before that I gained a degree and PhD in Earth Sciences. I have gradually found myself moving from science to software development, so working at the Met Office is a great place to combine both these interests. In particular the Informatics Lab here is leading the Met Office in bringing scientists, technologists and designers together to collaborate on the same projects.

--- a/_profiles/alberto-arribas.md
+++ b/_profiles/alberto-arribas.md
@@ -4,10 +4,11 @@ layout: profile
 name: Alberto Arribas
 summary: Head of Informatics Lab
 affiliation: core
+current: true
 twitter-url: https://twitter.com/informatics_lab
 github-url: https://github.com/alberto-arribas
 email: alberto.arribas@informaticslab.co.uk
-mugshot: AlbertoPhoto_BW.jpg
+mugshot: https://images.informaticslab.co.uk/profiles/cropped/alberto-arribas.png
 ---
 
 Hola! I am a lucky chap, I like what I do for a living.

--- a/_profiles/antoine-de-daran.md
+++ b/_profiles/antoine-de-daran.md
@@ -3,12 +3,13 @@ title: Antoine De Daran
 layout: profile
 name: Antoine de Daran
 summary: Antoine is a curious French trainee who studies applied mathematics.
-affiliation: past-member
+affiliation: intern
+current: false
 twitter-url: https://twitter.com/AntoineDeDaran
 linkedin-url: https://fr.linkedin.com/in/antoine-de-daran-a2a671a9
 github-url: https://github.com/AntoinedDMO
 email: antoine.de.daran@informaticslab.co.uk
-mugshot: antoinededaran.jpg
+mugshot: https://images.informaticslab.co.uk/antoinededaran.jpg
 ---
 
 I am a forth year student from "Ecole Centrale de Nantes", a french engineering school. From April 2016 to August 2016, I will be part of the Informatics Lab team.

--- a/_profiles/dean-jones.md
+++ b/_profiles/dean-jones.md
@@ -4,20 +4,21 @@ layout: profile
 name: Dean Jones
 summary: Senior Designer and creative enthusiast
 affiliation: core
+current: true
 linkedin-url: https://www.linkedin.com/in/dean-jones-52b57873?trk=nav_responsive_tab_profile_pic
 github-url: https://github.com/deanjones1989
 email: dean.jones@informaticslab.co.uk
 twitter: https://twitter.com/hattipcreative
 website: www.hattipcreative.com
-mugshot: 
+mugshot: https://images.informaticslab.co.uk/profiles/cropped/dean-jones.png
 ---
 
 Hey, I'm Dean!
 
-From an early age I’d jump at the chance to work with anything involving colouring pencils and a pot of PVA - all hail Neil Buchanan. 
+From an early age I’d jump at the chance to work with anything involving colouring pencils and a pot of PVA - all hail Neil Buchanan.
 
 After studying Art and Graphic Design in school, I went on to further my knowledge at college and University, where I was greeted with new methods of communicating design and unexpected all-nighters in the library.
 
-My career in Design began during 2008, where I was tasked to create signage for small business' in Torbay. I then moved onto branding, information, and then editorial design where daily tasks included the design and management of magazines which were printed in the 00’s of 000’s. 
+My career in Design began during 2008, where I was tasked to create signage for small business' in Torbay. I then moved onto branding, information, and then editorial design where daily tasks included the design and management of magazines which were printed in the 00’s of 000’s.
 
-At present, I'm grateful to be a Senior Designer at the Met Office in Exeter, where my love for everything creative is ever-more growing! Working on various projects, daily duties could range from designing bespoke animations and info-graphics, to collaborating with scientists and programmers to create pixel-perfect visuals for tomorrow's technology. 
+At present, I'm grateful to be a Senior Designer at the Met Office in Exeter, where my love for everything creative is ever-more growing! Working on various projects, daily duties could range from designing bespoke animations and info-graphics, to collaborating with scientists and programmers to create pixel-perfect visuals for tomorrow's technology.

--- a/_profiles/jacob-tomlinson.md
+++ b/_profiles/jacob-tomlinson.md
@@ -4,12 +4,13 @@ layout: profile
 name: Jacob Tomlinson
 summary: Jacob builds servers, websites and is madly in love with GitHub.
 affiliation: core
+current: true
 twitter-url: http://www.twitter.com/_jacobtomlinson
 linkedin-url: http://www.linkedin.com/pub/jacob-tomlinson/34/b67/84
 github-url: http://github.com/jacobtomlinson
 email: jacob.tomlinson@informaticslab.co.uk
 stackoverflow-url: http://stackoverflow.com/users/1003288/jacob-tomlinson
-mugshot: jacob-tomlinson.jpg
+mugshot: https://images.informaticslab.co.uk/profiles/cropped/jacob-tomlinson.png
 ---
 
 Jacob is an engineer with experience in software development and operational system administration. He uses these skills to ensure the lab is building prototypes on the cutting edge of technology.

--- a/_profiles/labby-rat.md
+++ b/_profiles/labby-rat.md
@@ -3,9 +3,10 @@ title: Labby Rat
 layout: profile
 name: Labby the Rat
 summary: Labby is the Informatics Lab rat in residence.
-affiliation: core
+affiliation: mascot
+current: true
 twitter-url: http://www.twitter.com/LabbyTheRat
-mugshot: tHD9RgYn.jpg
+mugshot: https://images.informaticslab.co.uk/profiles/cropped/labby-the-rat.jpg
 ---
 
 Following an assignment as mascot for the Visual Weather development team, I have recently taken up the post of rat in residence in the Informatics Lab.

--- a/_profiles/michael-saunby.md
+++ b/_profiles/michael-saunby.md
@@ -3,12 +3,13 @@ title: Michael Saunby
 layout: profile
 name: Michael Saunby
 summary: Michael uses 100% of his brain.
-affiliation: past-member
+affiliation: core
+current: false
 twitter-url: http://www.twitter.com/msaunby
 linkedin-url: https://www.linkedin.com/in/michaelsaunby
 github-url: http://github.com/msaunby
 email: michael.saunby@informaticslab.co.uk
-mugshot: michael-saunby.jpg
+mugshot: https://images.informaticslab.co.uk/michael-saunby.jpg
 ---
 
 Michael is a software engineer and intrapreneur. He has degrees and diplomas in electronic engineering, land management, and an MBA from the Open University. His working life has been spent alongside weather and climate scientists helping to realise some of their more ambitious undertakings.

--- a/_profiles/niall-robinson.md
+++ b/_profiles/niall-robinson.md
@@ -4,12 +4,13 @@ layout: profile
 name: Niall Robinson
 summary: Niall is interested in what information is hidden in data.
 affiliation: core
+current: true
 twitter-url: http://www.twitter.com/niallhrobinson
 linkedin-url: http://www.linkedin.com/in/niallhrobinson
 github-url: http://github.com/niallrobinson
 email: niall.robinson@informaticslab.co.uk
 stackoverflow-url: http://stackoverflow.com/users/1862785/nrob
-mugshot: niall-robinson.png
+mugshot: https://images.informaticslab.co.uk/profiles/cropped/niall-robinson.png
 ---
 
 I'm one of the Met Office Informatics Lab's resident "scientists". Currently, "doing science" involves lots of stuff that isn't science - moving data about in batch jobs, writing thousands of lines of code, reading piles of academic papers. I think Lab can let everyone get closer to what science is really about: understanding what's going on. I've always been passionate about communicating science in a way that makes people want to listen (at least, that's the goal).

--- a/_profiles/rachel-prudden.md
+++ b/_profiles/rachel-prudden.md
@@ -4,10 +4,11 @@ layout: profile
 name: Rachel Prudden
 summary: Rachel is a programmer who used to be a mathematician.
 affiliation: core
+current: true
 twitter-url: https://twitter.com/RachelPrudden
 github-url: https://github.com/RPrudden
 email: rachel.prudden@informaticslab.co.uk
-mugshot: rachel-prudden.jpg
+mugshot: https://images.informaticslab.co.uk/profiles/cropped/rachel-prudden.png
 ---
 
 I joined the Met Office in 2012 as a Visual Weather developer for the GeoApps team. Since then I've been involved in various projects related to data visualisation, mainly working in Python and JavaScript. I've always been curious about the scientific side of meteorology, and I'd like to see the Lab start to bridge the gap between Science and Technology.

--- a/_profiles/richard-hogben.md
+++ b/_profiles/richard-hogben.md
@@ -3,7 +3,8 @@ title: Richard.hogben
 layout: profile
 name: Richard Hogben
 summary: Richard has a variety of skills which he hopes to use in the Lab.
-affiliation: past-member
+affiliation: core
+current: false
 email: richard.hogben@informaticslab.co.uk
 ---
 

--- a/_profiles/ross-middleham.md
+++ b/_profiles/ross-middleham.md
@@ -4,10 +4,11 @@ layout: profile
 name: Ross Middleham
 summary: Creative design is what I do.
 affiliation: core
+current: true
 twitter-url: http://www.twitter.com/rossymids
 github-url: https://github.com/RossJM
 email: ross.middleham@informaticslab.co.uk
-mugshot: RM-sketching.jpg
+mugshot: https://images.informaticslab.co.uk/profiles/cropped/ross-middleham.png
 ---
 
 Creative design is what I do. I live and breathe design taking inspiration from everything around me.

--- a/_profiles/simon-stanley.md
+++ b/_profiles/simon-stanley.md
@@ -3,10 +3,11 @@ title: Simon Stanley
 layout: profile
 name: Simon Stanley
 summary: Simon is a maths man by trade and Python programmer by occupation.
-affiliation: past-member
+affiliation: core
+current: false
 github-url: http://github.com/simonstanley
 email: simon.stanley87@gmail.com
-mugshot: simon-stanley.jpg
+mugshot: https://images.informaticslab.co.uk/simon-stanley.jpg
 ---
 
 I joined the Met Office in 2012, spent two (and a bit) years in the climate applications team where I pondered probabilities, visualised verification and danced with data!

--- a/_profiles/tom-powell.md
+++ b/_profiles/tom-powell.md
@@ -4,12 +4,13 @@ layout: profile
 name: Tom Powell
 summary: Tom is a developer who works across the stack.
 affiliation: core
-twitter-url: 
-linkedin-url: 
+current: true
+twitter-url:
+linkedin-url:
 github-url: http://github.com/tpowellmeto
 email: thomas.powell@informaticslab.co.uk
-stackoverflow-url: 
-mugshot: tom-powell.png
+stackoverflow-url:
+mugshot: https://images.informaticslab.co.uk/profiles/cropped/tom-powell.png
 ---
 
 Hello! I'm Tom.


### PR DESCRIPTION
Affiliations are now static and do not change if a person leaves the team. Currently used affiliation values are `core`, `intern` and `mascot`.

There is also a new value for the profiles called `current` which is a boolean representing if someone currently works in the lab.

I've also updates mugshot urls to be absolute and not relative to a magic prefix. 

The new mugshots have been updated.