### PR TITLE
Add script to upload images

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ description: The Met Office Informatics Lab combines scientists, technologists, 
   designers to make environmental science and data useful. We build prototypes to
   try out new technologies and techniques to push the boundaries of science, technology
   and design.
-baseurl: 
+baseurl:
 url: http://www.informaticslab.co.uk
 github-url: http://github.com/met-office-lab/
 twitter-url: https://twitter.com/informatics_lab
@@ -47,6 +47,7 @@ exclude:
 - node_modules
 - bower_components
 - tests
+- scripts
 - vendor
 - tmp
 sass:

--- a/scripts/upload_image.sh
+++ b/scripts/upload_image.sh
@@ -6,6 +6,7 @@
 #
 # Requirements:
 #   * aws-cli
+#   * openssl (for random string generation)
 #   * Write permission to the informatics-webimages bucket
 #
 # Tip: you may want to alias this to `blogimage` or something.
@@ -13,13 +14,31 @@
 # Bail if no file specified
 : ${1?"File to upload required. Usage: $0 <image_path>"}
 
+# Vermose mode
+_V=0
+while getopts "v" OPTION
+do
+  case $OPTION in
+    v) _V=1
+       shift
+       ;;
+  esac
+done
+
+# Function to echo only when verbose mode is on
+function log () {
+    if [[ $_V -eq 1 ]]; then
+        echo "$@"
+    fi
+}
+
 # Define variables
 BUCKET="informatics-webimages"
-LOCAL_FILE=$1
+LOCAL_FILE="$1"
 IMAGE=$(basename ${LOCAL_FILE})
-EXTENSION="${IMAGE##*.}"
+EXTENSION="${LOCAL_FILE##*.}"
 FILENAME=$(openssl rand -hex 16)
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 
 # Figure out where to put the image
 if [[ $BRANCH == "project-"* ]]; then
@@ -31,18 +50,19 @@ else
 fi
 
 # Check if the file exists
-if [ ! -f $LOCAL_FILE ]; then
+if [ ! -f "$LOCAL_FILE" ]; then
     echo "File \"$LOCAL_FILE\" not found!"
     exit 1
 fi
 
 # Upload to S3
-echo "Uploading to S3"
-aws s3 cp $LOCAL_FILE s3://${BUCKET}/${TYPE}/${FILENAME}.${EXTENSION}
+log "Uploading to S3"
+aws s3 cp "$LOCAL_FILE" s3://${BUCKET}/${TYPE}/${FILENAME}.${EXTENSION} > /dev/null 2>&1
 
 # Notify the user of success or failure
 if [ $? -eq 0 ]; then
-  echo "Your file is now available at https://images.informaticslab.co.uk/${TYPE}/${FILENAME}.${EXTENSION}"
+  log "Your file is now available "
+  echo "https://images.informaticslab.co.uk/${TYPE}/${FILENAME}.${EXTENSION}"
 else
   echo "Upload failed"
 fi

--- a/scripts/upload_image.sh
+++ b/scripts/upload_image.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# A script to upload images to the Lab S3 images bucket. It will put it in
+# the correct folder for projects and articles depending on your branch name.
+# It will also rename the file to something random url endoded.
+#
+# Requirements:
+#   * aws-cli
+#   * Write permission to the informatics-webimages bucket
+#
+# Tip: you may want to alias this to `blogimage` or something.
+
+# Bail if no file specified
+: ${1?"File to upload required. Usage: $0 <image_path>"}
+
+# Define variables
+BUCKET="informatics-webimages"
+LOCAL_FILE=$1
+IMAGE=$(basename ${LOCAL_FILE})
+EXTENSION="${IMAGE##*.}"
+FILENAME=$(openssl rand -hex 16)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Figure out where to put the image
+if [[ $BRANCH == "project-"* ]]; then
+  TYPE="projects/$BRANCH"
+elif [[ $BRANCH == "article-"* ]]; then
+  TYPE="articles/$BRANCH"
+else
+  TYPE="misc"
+fi
+
+# Check if the file exists
+if [ ! -f $LOCAL_FILE ]; then
+    echo "File \"$LOCAL_FILE\" not found!"
+    exit 1
+fi
+
+# Upload to S3
+echo "Uploading to S3"
+aws s3 cp $LOCAL_FILE s3://${BUCKET}/${TYPE}/${FILENAME}.${EXTENSION}
+
+# Notify the user of success or failure
+if [ $? -eq 0 ]; then
+  echo "Your file is now available at https://images.informaticslab.co.uk/${TYPE}/${FILENAME}.${EXTENSION}"
+else
+  echo "Upload failed"
+fi

--- a/scripts/upload_image.sh
+++ b/scripts/upload_image.sh
@@ -10,6 +10,7 @@
 #   * Write permission to the informatics-webimages bucket
 #
 # Tip: you may want to alias this to `blogimage` or something.
+#      alias blogimage="/path/to/blog/scripts/upload_image.sh"
 
 # Bail if no file specified
 : ${1?"File to upload required. Usage: $0 <image_path>"}


### PR DESCRIPTION
Added a script to be used when writing a post to upload images. You just give it the filepath you want to upload and it puts to S3 and gives you back a url to include in your post.

Example
```bash
$ scripts/upload_image.sh ~/Downloads/alberto-arribas.png
https://images.informaticslab.co.uk/misc/c1f1048fb919df1574543feb7a916eb7.png
```

Or if you're feeling verbose

```shell
$ scripts/upload_image.sh -v ~/Downloads/alberto-arribas.png
Uploading to S3
upload: ../../../Downloads/alberto-arribas.png to s3://informatics-webimages/misc/d3843a53aa7157d43b7d60b211bf4b59.png
Your file is now available at https://images.informaticslab.co.uk/misc/d3843a53aa7157d43b7d60b211bf4b59.png
```

You might find it easier to alias this:
`alias blogimage="/path/to/blog/scripts/upload_image.sh"`