### PR TITLE
Fixed code block formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,5 @@ Copied the url to your clipboard!
 $ blogimage
 Uploading from your clipboard
 https://images.informaticslab.co.uk/misc/d7420c5a925dac8d397a6bd6e358f39f.png
-Copied the url to your clipboard!```
+Copied the url to your clipboard!
+```


### PR DESCRIPTION
The three backticks on the final line were being rendered in Markdown previews. Moved them to a new line after the code to close the block and fix the render.